### PR TITLE
Condor version is needed in the url path for HTCondor.

### DIFF
--- a/tasks/Debian.yaml
+++ b/tasks/Debian.yaml
@@ -22,7 +22,7 @@
 
 - name: Add APT repository for HTCondor
   ansible.builtin.apt_repository:
-    repo: 'deb [arch=amd64] https://research.cs.wisc.edu/htcondor/repo/ubuntu/{{ htcondor_channel }} {{ ansible_distribution_release }} main'
+    repo: 'deb [arch=amd64] https://research.cs.wisc.edu/htcondor/repo/ubuntu/{{ htcondor_version }} {{ ansible_distribution_release }} main'
     state: present
     update_cache: true
 

--- a/tasks/RedHat.yaml
+++ b/tasks/RedHat.yaml
@@ -32,7 +32,7 @@
 
 - name: Add YUM repository for HTCondor
   ansible.builtin.yum:
-    name: https://research.cs.wisc.edu/htcondor/repo/{{ htcondor_channel }}/htcondor-release-current.el{{ ansible_distribution_major_version }}.noarch.rpm
+    name: https://research.cs.wisc.edu/htcondor/repo/{{ htcondor_version }}/htcondor-release-current.el{{ ansible_distribution_major_version }}.noarch.rpm
     state: present
 
 - name: Enable extra repositories in RHEL8

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,7 +49,7 @@
   ansible.builtin.file:
     path: /etc/condor/config.d/00-htcondor-9.0.config
     state: absent
-  when: htcondor_version == "10.x"
+    when: htcondor_version is match('^(?:10|23|24)(?:\\.|$)')
   notify: Restart htcondor
 
 - name: Get password directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,7 +49,7 @@
   ansible.builtin.file:
     path: /etc/condor/config.d/00-htcondor-9.0.config
     state: absent
-    when: htcondor_version is match('^(?:10|23|24)(?:\\.|$)')
+  when: htcondor_version is match('^(?:10|23|24)(?:\\.|$)')
   notify: Restart htcondor
 
 - name: Get password directory


### PR DESCRIPTION
This PR reflect the changes introduced by Sebastian in the original grycap role with this PR:
https://github.com/grycap/ansible-role-htcondor/pull/16/files

htcondor_channel could not point to the right url, the htcondor_version is needed.
Moreover, it should also be compatible with 23 and 24 version.

I did minimal changes for not breaking anything, but in principle the htcondor_channel is no more used and can be removed and the README can be updated (of course I can do).